### PR TITLE
Fix missing React hook imports in MuseumScene

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useState, useEffect } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import { OrbitControls, useTexture } from '@react-three/drei';
 import * as THREE from 'three';


### PR DESCRIPTION
## Summary
- import the missing `useState` and `useEffect` hooks used inside `MuseumScene`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffa88d700083269dabbae227162dac