### PR TITLE
Ensure doorway hitboxes ignore depth

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -282,7 +282,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
           }}
         >
           <planeGeometry args={responsive.isMobile ? [3.2, 6.8] : [2.6, 6]} />
-          <meshBasicMaterial transparent opacity={0} />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} depthTest={false} />
         </mesh>
       ))}
 


### PR DESCRIPTION
## Summary
- disable depth interactions on invisible doorway hitboxes so they stay clickable without hiding labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b60f4504c8326828c0b471a696864