### PR TITLE
Adjust default museum camera to face Alumni doorway

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -52,7 +52,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
   const controlsRef = useRef<any>(null);
   const { camera } = useThree();
 
-  const initialCameraPos = useRef(new THREE.Vector3(0, 2.5, 0.01));
+  const initialCameraPos = useRef(new THREE.Vector3(-0.1, 2.5, 0));
   const animationCurve = useRef<THREE.CatmullRomCurve3 | null>(null);
   const animationProgress = useRef(0);
   const animationDuration = useRef(3);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -155,7 +155,7 @@ const Index = () => {
           <div style={{ display: activeRoom ? 'none' : 'block', width: '100%', height: '100%' }}>
             <Canvas
               key={cameraKey}
-              camera={{ position: [0, 2.5, 0.01], near: 0.01, far: 60, fov: responsive.cameraFOV }}
+              camera={{ position: [-0.1, 2.5, 0], near: 0.01, far: 60, fov: responsive.cameraFOV }}
               shadows
               gl={{ 
                 antialias: !responsive.isMobile, 


### PR DESCRIPTION
## Summary
- update the museum scene's initial camera position so the idle view points toward the Alumni/Class Composites doorway
- synchronize the Canvas camera defaults with the new initial orientation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b6c5726988326a7d894f1484a21e7