### PR TITLE
Fix doorway navigation links and add direct link buttons

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -4,9 +4,10 @@ import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
 import { useResponsive } from '@/hooks/useResponsive';
 import { RotundaGeometry } from './RotundaGeometry';
+import { DOORWAYS, type Doorway } from '@/data/doorways';
 
 interface MuseumSceneProps {
-  onDoorClick: (key: string) => void;
+  onDoorClick: (door: Doorway) => void;
   onResetCamera?: () => void;
   selectedRoom?: string | null;
   onZoomComplete?: (roomKey: string) => void;
@@ -21,29 +22,12 @@ const calculateNichePosition = (angle: number, radius: number = 9): [number, num
   ];
 };
 
-// Niche positions for clickable areas (4 main display niches in rotunda)
-const DOORS = [
-  { 
-    key: 'Alumni/Class Composites', 
-    position: calculateNichePosition(0), 
-    rotation: [0, Math.PI, 0] as [number, number, number] 
-  },
-  { 
-    key: 'Publications (Amicus, Legal Eye, Law Review, Directory)', 
-    position: calculateNichePosition(Math.PI / 2), 
-    rotation: [0, -Math.PI / 2, 0] as [number, number, number] 
-  },
-  { 
-    key: 'Historical Photos/Archives', 
-    position: calculateNichePosition(Math.PI), 
-    rotation: [0, 0, 0] as [number, number, number] 
-  },
-  { 
-    key: 'Faculty & Staff', 
-    position: calculateNichePosition(Math.PI * 1.5), 
-    rotation: [0, Math.PI / 2, 0] as [number, number, number] 
-  },
-];
+// Augment doorway metadata with positions and rotations for 3D interaction
+const DOORS = DOORWAYS.map((door) => ({
+  ...door,
+  position: calculateNichePosition(door.angle),
+  rotation: [0, (door.angle + Math.PI) % (Math.PI * 2), 0] as [number, number, number],
+}));
 
 export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomComplete }: MuseumSceneProps) {
   const responsive = useResponsive();
@@ -275,7 +259,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
           rotation={door.rotation}
           onClick={(e) => {
             e.stopPropagation();
-            onDoorClick(door.key);
+            onDoorClick(door);
             // Haptic feedback on mobile
             if (responsive.isMobile && 'vibrate' in navigator) {
               navigator.vibrate(50);
@@ -292,7 +276,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
             document.body.style.cursor = 'default';
           }}
         >
-          <planeGeometry args={responsive.isMobile ? [3.2, 6.8] : [2.6, 6]} />
+          <planeGeometry args={responsive.isMobile ? [3.6, 7.2] : [3.1, 6.4]} />
           <meshBasicMaterial transparent opacity={0} depthWrite={false} depthTest={false} />
         </mesh>
       ))}

--- a/src/components/RotundaGeometry.tsx
+++ b/src/components/RotundaGeometry.tsx
@@ -1,16 +1,16 @@
 import * as THREE from 'three';
 import { useMemo } from 'react';
 import { Text } from '@react-three/drei';
+import { DOORWAYS } from '@/data/doorways';
 
 interface RotundaGeometryProps {
   radius?: number;
   columnCount?: number;
 }
 
-// 4 doorway positions at cardinal directions
-const DOORWAY_ANGLES = [0, Math.PI / 2, Math.PI, Math.PI * 1.5];
+// 4 doorway positions at cardinal directions (sourced from shared doorway config)
+const DOORWAY_ANGLES = DOORWAYS.map((door) => door.angle);
 const DOORWAY_WIDTH = Math.PI / 6; // Width of each doorway opening (30 degrees)
-const DOORWAY_TITLES = ['Alumni', 'Publications', 'Archives', 'Faculty'];
 
 export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeometryProps) {
   // Calculate column positions - only between doorways
@@ -210,8 +210,9 @@ export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeomet
 
 
       {/* Doorway title text - curved along the wall */}
-      {DOORWAY_ANGLES.map((angle, i) => {
-        const title = DOORWAY_TITLES[i];
+      {DOORWAYS.map((door, i) => {
+        const angle = door.angle;
+        const title = door.shortTitle;
         const textRadius = radius + 0.48; // Just inside the inner wall
         const arcLength = DOORWAY_WIDTH * textRadius * 0.9; // Stay within doorway
 

--- a/src/data/doorways.ts
+++ b/src/data/doorways.ts
@@ -1,0 +1,43 @@
+export interface Doorway {
+  key: string;
+  title: string;
+  shortTitle: string;
+  description: string;
+  angle: number;
+  link: string;
+}
+
+export const DOORWAYS: Doorway[] = [
+  {
+    key: 'Alumni/Class Composites',
+    title: 'Alumni / Class Composites',
+    shortTitle: 'Alumni',
+    description: 'Historic class portraits and alumni achievements',
+    angle: 0,
+    link: 'https://law.mc.edu/alumni/class-composites/',
+  },
+  {
+    key: 'Publications (Amicus, Legal Eye, Law Review, Directory)',
+    title: 'Publications',
+    shortTitle: 'Publications',
+    description: 'Student and faculty publications, journals, and newsletters',
+    angle: Math.PI / 2,
+    link: 'https://law.mc.edu/publications/',
+  },
+  {
+    key: 'Historical Photos/Archives',
+    title: 'Historical Photos / Archives',
+    shortTitle: 'Archives',
+    description: 'Photographic and archival collections from MC Law history',
+    angle: Math.PI,
+    link: 'https://law.mc.edu/library/archives/',
+  },
+  {
+    key: 'Faculty & Staff',
+    title: 'Faculty & Staff',
+    shortTitle: 'Faculty',
+    description: 'Profiles and contact information for MC Law faculty and staff',
+    angle: (Math.PI * 3) / 2,
+    link: 'https://law.mc.edu/faculty/',
+  },
+];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { OrbitControls } from '@react-three/drei';
 import { useResponsive } from '@/hooks/useResponsive';
+import { DOORWAYS, type Doorway } from '@/data/doorways';
 
 const ROOM_CONTENT: Record<string, { title: string; items: Array<{ title: string; description: string }> }> = {
   'Alumni/Class Composites': {
@@ -47,6 +48,7 @@ const ROOM_CONTENT: Record<string, { title: string; items: Array<{ title: string
 
 const Index = () => {
   const responsive = useResponsive();
+  const [selectedDoor, setSelectedDoor] = useState<Doorway | null>(null);
   const [selectedRoom, setSelectedRoom] = useState<string | null>(null);
   const [activeRoom, setActiveRoom] = useState<string | null>(null);
   const [showRoomPanel, setShowRoomPanel] = useState(false);
@@ -54,13 +56,15 @@ const Index = () => {
   const [cameraKey, setCameraKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
-  const handleDoorClick = (roomKey: string) => {
-    setSelectedRoom(roomKey);
+  const handleDoorClick = (door: Doorway) => {
+    setSelectedDoor(door);
+    setSelectedRoom(door.key);
     setActiveRoom(null);
     setShowRoomPanel(false); // Hide panel during transition
   };
 
   const handleCloseRoom = () => {
+    setSelectedDoor(null);
     setSelectedRoom(null);
     setActiveRoom(null);
     setShowRoomPanel(false);
@@ -72,6 +76,7 @@ const Index = () => {
   };
 
   const handleResetCamera = () => {
+    setSelectedDoor(null);
     setSelectedRoom(null);
     setActiveRoom(null);
     setShowRoomPanel(false);
@@ -211,13 +216,26 @@ const Index = () => {
 
         {/* Overlay controls */}
         <div className="pointer-events-none absolute inset-0 z-[2]">
-          <div className="flex gap-2 p-2 md:p-3">
+          <div className="flex flex-wrap items-center gap-2 p-2 md:p-3">
             <Button
               onClick={handleResetCamera}
               className="pointer-events-auto bg-accent px-3 py-2 text-sm font-black text-accent-foreground shadow-[0_10px_24px_rgba(0,0,0,0.35)] hover:bg-accent/90 md:px-4 md:text-base"
             >
               Reset View
             </Button>
+            {DOORWAYS.map((door) => (
+              <Button
+                key={door.key}
+                asChild
+                size="sm"
+                variant="secondary"
+                className="pointer-events-auto bg-primary/40 text-primary-foreground shadow-[0_6px_18px_rgba(0,0,0,0.35)] backdrop-blur-sm transition-colors hover:bg-primary/55"
+              >
+                <a href={door.link} target="_blank" rel="noreferrer">
+                  {door.shortTitle} ↗
+                </a>
+              </Button>
+            ))}
           </div>
 
           {/* Hint text */}
@@ -247,6 +265,18 @@ const Index = () => {
                 <CardTitle className="flex-1 text-lg font-black tracking-tight md:text-2xl">
                   {responsive.isMobile ? roomData.title.split('(')[0].trim() : roomData.title}
                 </CardTitle>
+                {selectedDoor && (
+                  <Button
+                    asChild
+                    variant="secondary"
+                    size="sm"
+                    className="pointer-events-auto bg-white/15 text-primary-foreground hover:bg-white/25"
+                  >
+                    <a href={selectedDoor.link} target="_blank" rel="noreferrer">
+                      Visit {selectedDoor.shortTitle} ↗
+                    </a>
+                  </Button>
+                )}
                 <Button
                   onClick={handleCloseRoom}
                   className="bg-accent px-3 py-2 text-sm font-black text-accent-foreground hover:bg-accent/90 md:px-4 md:text-base"


### PR DESCRIPTION
## Summary
- centralize doorway metadata so 3D geometry, hotspots, and labels use the same configuration
- correct the faculty and publications doorway targets and expose the official URLs in quick-link buttons and the room panel
- enlarge the interactive doorway hit boxes to make each door easier to click on touch and desktop devices

## Testing
- npm run lint *(fails: pre-existing lint issues in ui components)*

------
https://chatgpt.com/codex/tasks/task_e_690b71a310008326aae559a3f2181bcb