### PR TITLE
Make lobby doorways clickable and add landing pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Alumni from "./pages/Alumni";
+import Publications from "./pages/Publications";
+import Archives from "./pages/Archives";
+import Faculty from "./pages/Faculty";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +20,10 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/alumni" element={<Alumni />} />
+          <Route path="/publications" element={<Publications />} />
+          <Route path="/archives" element={<Archives />} />
+          <Route path="/faculty" element={<Faculty />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/RotundaGeometry.tsx
+++ b/src/components/RotundaGeometry.tsx
@@ -217,7 +217,13 @@ export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeomet
         const arcLength = DOORWAY_WIDTH * textRadius * 0.9; // Stay within doorway
 
         return (
-          <group key={`doorway-title-${i}`} rotation={[0, angle, 0]} renderOrder={10}>
+          <group
+            key={`doorway-title-${i}`}
+            name={`door-label-${title.toLowerCase()}`}
+            rotation={[0, angle, 0]}
+            renderOrder={10}
+            userData={{ doorKey: title }}
+          >
             <Text
               position={[textRadius, 5.6, 0]}
               rotation={[0, -Math.PI / 2, 0]}
@@ -232,6 +238,8 @@ export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeomet
               outlineColor="#FFFFFF"
               depthOffset={-1}
               curveRadius={-textRadius}
+              name={`door-label-text-${title.toLowerCase()}`}
+              userData={{ doorKey: title, text: title }}
             >
               {title}
             </Text>

--- a/src/components/doorways/DoorwayLanding.tsx
+++ b/src/components/doorways/DoorwayLanding.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
+interface DoorwayLandingProps {
+  title: string;
+  description: string;
+  highlights?: Array<{ title: string; description: string }>;
+  children?: ReactNode;
+}
+
+export function DoorwayLanding({ title, description, highlights = [], children }: DoorwayLandingProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="bg-gradient-to-b from-primary to-primary/85 px-6 py-10 text-primary-foreground shadow-[0_12px_36px_rgba(0,0,0,0.45)] md:px-12 md:py-16">
+        <div className="mx-auto w-full max-w-5xl space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-foreground/70">MC Virtual Museum</p>
+          <h1 className="text-3xl font-black tracking-tight md:text-5xl">{title}</h1>
+          <p className="max-w-2xl text-base font-medium text-primary-foreground/85 md:text-lg">{description}</p>
+          <Button asChild size="lg" variant="secondary" className="mt-4">
+            <Link to="/">Return to Lobby</Link>
+          </Button>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl flex-1 space-y-10 px-6 py-10 md:px-12 md:py-14">
+        {highlights.length > 0 && (
+          <section>
+            <h2 className="text-xl font-bold tracking-tight text-foreground md:text-2xl">Highlights</h2>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {highlights.map((item, index) => (
+                <article key={`${item.title}-${index}`} className="rounded-xl border border-white/10 bg-primary/10 p-5 shadow-[0_12px_32px_rgba(0,0,0,0.35)]">
+                  <h3 className="text-lg font-semibold text-foreground">{item.title}</h3>
+                  <p className="text-sm text-muted-foreground">{item.description}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {children}
+      </main>
+
+      <footer className="bg-primary/80 px-6 py-4 text-xs text-muted-foreground md:px-12 md:py-6">
+        <div className="mx-auto flex max-w-5xl items-center justify-between">
+          <span>© {new Date().getFullYear()} Mississippi College School of Law</span>
+          <span className="hidden md:inline">Navigate back to explore more exhibits</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/data/roomContent.ts
+++ b/src/data/roomContent.ts
@@ -1,0 +1,47 @@
+export interface RoomContentEntry {
+  title: string;
+  items: Array<{ title: string; description: string }>;
+}
+
+export const ROOM_CONTENT: Record<string, RoomContentEntry> = {
+  'Alumni/Class Composites': {
+    title: 'Alumni/Class Composites',
+    items: [
+      { title: 'Class of 2023', description: 'Recent graduates and their achievements' },
+      { title: 'Class of 2020', description: 'Celebrating our alumni' },
+      { title: 'Class of 2015', description: 'A decade of success' },
+    ],
+  },
+  'Publications (Amicus, Legal Eye, Law Review, Directory)': {
+    title: 'Publications (Amicus, Legal Eye, Law Review, Directory)',
+    items: [
+      { title: 'Amicus Newsletter', description: 'Latest legal insights and updates' },
+      { title: 'Legal Eye Journal', description: 'Student perspectives on law' },
+      { title: 'Law Review', description: 'Scholarly articles and analysis' },
+      { title: 'Law School Directory', description: 'Comprehensive faculty and student listings' },
+    ],
+  },
+  'Historical Photos/Archives': {
+    title: 'Historical Photos/Archives',
+    items: [
+      { title: 'Founding Years', description: 'The establishment of MC Law School' },
+      { title: 'Notable Cases', description: 'Historic legal proceedings' },
+      { title: 'Campus Evolution', description: 'How our facilities have grown' },
+    ],
+  },
+  'Faculty & Staff': {
+    title: 'Faculty & Staff',
+    items: [
+      { title: 'Dean of Law', description: 'Leadership and vision for the school' },
+      { title: 'Distinguished Professors', description: 'Meet our expert faculty' },
+      { title: 'Support Staff', description: 'The team behind student success' },
+    ],
+  },
+};
+
+export const DOOR_CONTENT: Record<'Alumni' | 'Publications' | 'Archives' | 'Faculty', RoomContentEntry> = {
+  Alumni: ROOM_CONTENT['Alumni/Class Composites'],
+  Publications: ROOM_CONTENT['Publications (Amicus, Legal Eye, Law Review, Directory)'],
+  Archives: ROOM_CONTENT['Historical Photos/Archives'],
+  Faculty: ROOM_CONTENT['Faculty & Staff'],
+};

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,33 @@ All colors MUST be HSL.
     height: 100dvh; /* Dynamic viewport height for mobile browsers */
   }
 }
+
+.sr-only-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only-link:focus,
+.sr-only-link:active {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  width: auto;
+  height: auto;
+  margin: 0;
+  clip: auto;
+  white-space: normal;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  box-shadow: var(--shadow-elegant);
+  z-index: 100;
+}

--- a/src/lib/scene/doorways.ts
+++ b/src/lib/scene/doorways.ts
@@ -1,0 +1,275 @@
+import * as THREE from 'three';
+import { DOORWAYS } from '@/data/doorways';
+
+export type DoorKey = 'Alumni' | 'Publications' | 'Archives' | 'Faculty';
+
+export const DOOR_LINKS: Record<DoorKey, string> = {
+  Alumni: '/alumni',
+  Publications: '/publications',
+  Archives: '/archives',
+  Faculty: '/faculty',
+};
+
+export interface DoorwayTarget {
+  key: DoorKey;
+  hitbox: THREE.Object3D;
+  label?: THREE.Object3D;
+}
+
+const DOOR_RADIUS = 9;
+const HITBOX_SIZE = new THREE.Vector3(3.8, 7.2, 0.6);
+
+const DOOR_NAME_LOOKUP: Partial<Record<DoorKey, string>> = {
+  Alumni: 'alumni',
+  Publications: 'publications',
+  Archives: 'archives',
+  Faculty: 'faculty',
+};
+
+function calculateDoorPosition(angle: number, radius: number = DOOR_RADIUS) {
+  return new THREE.Vector3(
+    Math.cos(angle) * radius,
+    3.2,
+    Math.sin(angle) * radius,
+  );
+}
+
+function findObjectsByName(root: THREE.Object3D, fragment: string) {
+  const matches: THREE.Object3D[] = [];
+  root.traverse((obj) => {
+    if (!obj.name) return;
+    if (obj.name.toLowerCase().includes(fragment.toLowerCase())) {
+      matches.push(obj);
+    }
+  });
+  return matches;
+}
+
+function findLabelForDoor(root: THREE.Object3D, key: DoorKey) {
+  let label: THREE.Object3D | undefined;
+  const needle = key.toLowerCase();
+  root.traverse((obj) => {
+    const directName = obj.name?.toLowerCase();
+    const userDataText = typeof obj.userData?.doorKey === 'string'
+      ? String(obj.userData.doorKey).toLowerCase()
+      : typeof obj.userData?.text === 'string'
+        ? String(obj.userData.text).toLowerCase()
+        : undefined;
+    const textContent = typeof (obj as any).text === 'string'
+      ? String((obj as any).text).toLowerCase()
+      : undefined;
+
+    if (directName === needle || userDataText === needle || textContent === needle) {
+      label = obj;
+    }
+  });
+  return label;
+}
+
+export function buildDoorwayTargets(root: THREE.Object3D): DoorwayTarget[] {
+  const targets: DoorwayTarget[] = [];
+
+  (Object.keys(DOOR_LINKS) as DoorKey[]).forEach((key) => {
+    const doorwayConfig = DOORWAYS.find((door) => door.shortTitle.toLowerCase() === key.toLowerCase());
+    if (!doorwayConfig) {
+      return;
+    }
+
+    const label = findLabelForDoor(root, key);
+    const nameFragment = DOOR_NAME_LOOKUP[key] ?? key.toLowerCase();
+    const candidateMeshes = findObjectsByName(root, nameFragment);
+    const doorMesh = candidateMeshes.find((obj) => obj instanceof THREE.Mesh) as THREE.Mesh | undefined;
+
+    let hitboxCenter = calculateDoorPosition(doorwayConfig.angle, DOOR_RADIUS);
+    const hitboxSize = HITBOX_SIZE.clone();
+
+    if (doorMesh) {
+      doorMesh.updateWorldMatrix(true, true);
+      const bounds = new THREE.Box3().setFromObject(doorMesh);
+      const size = new THREE.Vector3();
+      const center = new THREE.Vector3();
+      bounds.getSize(size);
+      bounds.getCenter(center);
+      hitboxCenter = center;
+      hitboxSize.set(
+        Math.max(size.x * 1.1, HITBOX_SIZE.x),
+        Math.max(size.y * 1.05, HITBOX_SIZE.y),
+        Math.max(size.z || HITBOX_SIZE.z, HITBOX_SIZE.z)
+      );
+    } else if (label) {
+      label.updateWorldMatrix(true, true);
+      const worldPos = new THREE.Vector3();
+      label.getWorldPosition(worldPos);
+      hitboxCenter = worldPos;
+      hitboxCenter.y = Math.max(hitboxCenter.y, HITBOX_SIZE.y * 0.45);
+    }
+
+    const geometry = new THREE.BoxGeometry(hitboxSize.x, hitboxSize.y, hitboxSize.z);
+    const material = new THREE.MeshBasicMaterial({ visible: false });
+    const hitbox = new THREE.Mesh(geometry, material);
+    hitbox.userData.doorKey = key;
+    hitbox.userData.autoDoorHitbox = true;
+    hitbox.name = `door-hitbox-${key.toLowerCase()}`;
+
+    hitbox.position.copy(hitboxCenter);
+    const rotationY = (doorwayConfig.angle + Math.PI) % (Math.PI * 2);
+    hitbox.rotation.set(0, rotationY, 0);
+
+    root.add(hitbox);
+
+    targets.push({
+      key,
+      hitbox,
+      label,
+    });
+  });
+
+  return targets;
+}
+
+interface EnableDoorwayInteractionsOptions {
+  canvas: HTMLCanvasElement;
+  sceneRoot: THREE.Object3D;
+  camera: THREE.Camera;
+  navigate?: (path: string) => void;
+  onDoorActivated?: (key: DoorKey) => void;
+}
+
+export function enableDoorwayInteractions({
+  canvas,
+  sceneRoot,
+  camera,
+  navigate,
+  onDoorActivated,
+}: EnableDoorwayInteractionsOptions) {
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  const targets = buildDoorwayTargets(sceneRoot);
+  const hitObjects = targets.flatMap((target) => [target.hitbox, target.label].filter(Boolean)) as THREE.Object3D[];
+
+  let pointerDownX = 0;
+  let pointerDownY = 0;
+
+  const setPointerFromEvent = (event: MouseEvent | PointerEvent | TouchEvent) => {
+    let clientX: number;
+    let clientY: number;
+
+    if (event instanceof TouchEvent) {
+      if (!event.changedTouches.length) return;
+      clientX = event.changedTouches[0].clientX;
+      clientY = event.changedTouches[0].clientY;
+    } else {
+      const mouseEvent = event as MouseEvent;
+      clientX = mouseEvent.clientX;
+      clientY = mouseEvent.clientY;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    pointer.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+  };
+
+  const pickObject = (event: MouseEvent | PointerEvent | TouchEvent) => {
+    setPointerFromEvent(event);
+    raycaster.setFromCamera(pointer, camera);
+    const intersections = raycaster.intersectObjects(hitObjects, true);
+    return intersections[0]?.object ?? null;
+  };
+
+  const resolveDoorKey = (object: THREE.Object3D | null): DoorKey | null => {
+    if (!object) return null;
+
+    const directKey = object.userData?.doorKey as DoorKey | undefined;
+    if (directKey && DOOR_LINKS[directKey]) {
+      return directKey;
+    }
+
+    const parentKey = object.parent?.userData?.doorKey as DoorKey | undefined;
+    if (parentKey && DOOR_LINKS[parentKey]) {
+      return parentKey;
+    }
+
+    const found = targets.find((target) => object === target.hitbox || object === target.label);
+    return found?.key ?? null;
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    const hoveredObject = pickObject(event);
+    const key = resolveDoorKey(hoveredObject);
+    canvas.style.cursor = key ? 'pointer' : 'default';
+  };
+
+  const activateDoor = (key: DoorKey) => {
+    onDoorActivated?.(key);
+    const path = DOOR_LINKS[key];
+    if (navigate) {
+      navigate(path);
+    } else {
+      window.location.href = path;
+    }
+  };
+
+  const handleClick = (event: MouseEvent) => {
+    if (Math.hypot(event.clientX - pointerDownX, event.clientY - pointerDownY) > 6) {
+      return;
+    }
+    const hoveredObject = pickObject(event);
+    const key = resolveDoorKey(hoveredObject);
+    if (!key) return;
+    activateDoor(key);
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    if (!event.changedTouches.length) return;
+    const touch = event.changedTouches[0];
+    if (Math.hypot(touch.clientX - pointerDownX, touch.clientY - pointerDownY) > 10) {
+      return;
+    }
+    const hoveredObject = pickObject(event);
+    const key = resolveDoorKey(hoveredObject);
+    if (!key) return;
+    activateDoor(key);
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    pointerDownX = event.clientX;
+    pointerDownY = event.clientY;
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    if (!event.changedTouches.length) return;
+    pointerDownX = event.changedTouches[0].clientX;
+    pointerDownY = event.changedTouches[0].clientY;
+  };
+
+  canvas.addEventListener('pointermove', handlePointerMove, { passive: true });
+  canvas.addEventListener('pointerdown', handlePointerDown, { passive: true });
+  canvas.addEventListener('click', handleClick, { passive: true });
+  canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
+  canvas.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+  const cleanup = () => {
+    canvas.style.cursor = 'default';
+    canvas.removeEventListener('pointermove', handlePointerMove);
+    canvas.removeEventListener('pointerdown', handlePointerDown);
+    canvas.removeEventListener('click', handleClick);
+    canvas.removeEventListener('touchstart', handleTouchStart);
+    canvas.removeEventListener('touchend', handleTouchEnd);
+
+    targets.forEach(({ hitbox }) => {
+      if (hitbox.parent) {
+        hitbox.parent.remove(hitbox);
+      }
+      if (hitbox instanceof THREE.Mesh && hitbox.userData?.autoDoorHitbox) {
+        hitbox.geometry.dispose();
+        if (Array.isArray(hitbox.material)) {
+          hitbox.material.forEach((mat) => mat.dispose());
+        } else {
+          hitbox.material.dispose();
+        }
+      }
+    });
+  };
+
+  return cleanup;
+}

--- a/src/pages/Alumni.tsx
+++ b/src/pages/Alumni.tsx
@@ -1,0 +1,12 @@
+import { DoorwayLanding } from '@/components/doorways/DoorwayLanding';
+import { DOOR_CONTENT } from '@/data/roomContent';
+
+const Alumni = () => (
+  <DoorwayLanding
+    title="Alumni & Class Composites"
+    description="Celebrate generations of MC Law graduates and explore class composites, milestone reunions, and alumni achievements."
+    highlights={DOOR_CONTENT.Alumni.items}
+  />
+);
+
+export default Alumni;

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -1,0 +1,12 @@
+import { DoorwayLanding } from '@/components/doorways/DoorwayLanding';
+import { DOOR_CONTENT } from '@/data/roomContent';
+
+const Archives = () => (
+  <DoorwayLanding
+    title="Historical Photos & Archives"
+    description="Discover the moments that shaped MC Law through curated photographs, artifacts, and archival records."
+    highlights={DOOR_CONTENT.Archives.items}
+  />
+);
+
+export default Archives;

--- a/src/pages/Faculty.tsx
+++ b/src/pages/Faculty.tsx
@@ -1,0 +1,12 @@
+import { DoorwayLanding } from '@/components/doorways/DoorwayLanding';
+import { DOOR_CONTENT } from '@/data/roomContent';
+
+const Faculty = () => (
+  <DoorwayLanding
+    title="Faculty & Staff"
+    description="Meet the educators, scholars, and professionals who lead and support the MC Law community."
+    highlights={DOOR_CONTENT.Faculty.items}
+  />
+);
+
+export default Faculty;

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -1,0 +1,12 @@
+import { DoorwayLanding } from '@/components/doorways/DoorwayLanding';
+import { DOOR_CONTENT } from '@/data/roomContent';
+
+const Publications = () => (
+  <DoorwayLanding
+    title="Publications & Journals"
+    description="Browse the scholarship and storytelling produced by MC Law students, faculty, and alumni across our flagship publications."
+    highlights={DOOR_CONTENT.Publications.items}
+  />
+);
+
+export default Publications;


### PR DESCRIPTION
## Summary
- remove the top-left doorway chips and replace them with hidden accessible shortcuts
- add Three.js raycast hitboxes for each doorway and wire clicks/touches to route navigation
- create dedicated landing pages for Alumni, Publications, Archives, and Faculty content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b8d74bae483268d245b0d8bf90d13