### PR TITLE
Align camera animations with doorway targets

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -38,8 +38,8 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
   const controlsRef = useRef<any>(null);
   const { camera, gl, scene } = useThree();
 
-  const initialCameraPos = useRef(new THREE.Vector3(-2.6, 2.8, 5.2));
-  const initialLookTarget = useRef(new THREE.Vector3(-0.6, 2.5, 0.4));
+  const initialCameraPos = useRef(new THREE.Vector3(6, 2.5, 0));
+  const initialLookTarget = useRef(new THREE.Vector3(-9, 2.5, 0));
   const animationCurve = useRef<THREE.CatmullRomCurve3 | null>(null);
   const animationProgress = useRef(0);
   const animationDuration = useRef(3);
@@ -194,19 +194,30 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
         const thresholdDistance = 9.5;
         const exitDistance = 12;
 
-        const approachPoint = doorDirection.clone().multiplyScalar(approachDistance).add(new THREE.Vector3(0, 2.4, 0));
-        const doorwayPoint = doorDirection.clone().multiplyScalar(thresholdDistance).add(new THREE.Vector3(0, 2.2, 0));
-        const exitPoint = doorDirection.clone().multiplyScalar(exitDistance).add(new THREE.Vector3(0, 2.1, 0));
+        const approachPoint = doorDirection.clone().multiplyScalar(approachDistance).add(new THREE.Vector3(0, 2.5, 0));
+        const doorwayPoint = doorDirection.clone().multiplyScalar(thresholdDistance).add(new THREE.Vector3(0, 2.5, 0));
+        const exitPoint = doorDirection.clone().multiplyScalar(exitDistance).add(new THREE.Vector3(0, 2.5, 0));
 
-        const points = [
-          start.clone(),
-          start.clone().add(liftOffset),
-          approachPoint,
-          doorwayPoint,
-          exitPoint,
-        ];
+        const horizontalDistanceFromCenter = Math.hypot(start.x, start.z);
+        const isNearCenter = horizontalDistanceFromCenter < 6;
 
-        const lookTarget = doorDirection.clone().multiplyScalar(exitDistance + 2).add(new THREE.Vector3(0, 2.2, 0));
+        const points = isNearCenter
+          ? [
+              start.clone(),
+              start.clone().add(liftOffset),
+              approachPoint,
+              doorwayPoint,
+              exitPoint,
+            ]
+          : [
+              start.clone(),
+              new THREE.Vector3(0, 2.8, 0),
+              approachPoint,
+              doorwayPoint,
+              exitPoint,
+            ];
+
+        const lookTarget = doorDirection.clone().multiplyScalar(exitDistance + 2).add(new THREE.Vector3(0, 2.5, 0));
 
         startAnimation(points, lookTarget, responsive.isMobile ? 3.8 : 3.2);
         hasNotifiedComplete.current = false;
@@ -296,7 +307,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
       <OrbitControls
         ref={controlsRef}
         enabled={!isAnimating}
-        target={[initialLookTarget.current.x, initialLookTarget.current.y, initialLookTarget.current.z]}
+        target={[-9, 2.5, 0]}
         enablePan={false}
         enableZoom={true}
         minDistance={0.01}

--- a/src/components/RotundaGeometry.tsx
+++ b/src/components/RotundaGeometry.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Text } from '@react-three/drei';
 import { DOORWAYS } from '@/data/doorways';
 
@@ -11,6 +11,45 @@ interface RotundaGeometryProps {
 // 4 doorway positions at cardinal directions (sourced from shared doorway config)
 const DOORWAY_ANGLES = DOORWAYS.map((door) => door.angle);
 const DOORWAY_WIDTH = Math.PI / 6; // Width of each doorway opening (30 degrees)
+
+interface DoorwayLabelTextProps {
+  title: string;
+  textRadius: number;
+  arcLength: number;
+}
+
+function DoorwayLabelText({ title, textRadius, arcLength }: DoorwayLabelTextProps) {
+  const textRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (textRef.current) {
+      textRef.current.curveRadius = -textRadius;
+      textRef.current.sync?.();
+    }
+  }, [textRadius]);
+
+  return (
+    <Text
+      ref={textRef}
+      position={[textRadius, 5.6, 0]}
+      rotation={[0, -Math.PI / 2, 0]}
+      fontSize={0.9}
+      color="#2C3E50"
+      anchorX="center"
+      anchorY="middle"
+      textAlign="center"
+      maxWidth={arcLength}
+      letterSpacing={0.03}
+      outlineWidth={0.02}
+      outlineColor="#FFFFFF"
+      depthOffset={-1}
+      name={`door-label-text-${title.toLowerCase()}`}
+      userData={{ doorKey: title, text: title }}
+    >
+      {title}
+    </Text>
+  );
+}
 
 export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeometryProps) {
   // Calculate column positions - only between doorways
@@ -224,25 +263,11 @@ export function RotundaGeometry({ radius = 10, columnCount = 12 }: RotundaGeomet
             renderOrder={10}
             userData={{ doorKey: title }}
           >
-            <Text
-              position={[textRadius, 5.6, 0]}
-              rotation={[0, -Math.PI / 2, 0]}
-              fontSize={0.9}
-              color="#2C3E50"
-              anchorX="center"
-              anchorY="middle"
-              textAlign="center"
-              maxWidth={arcLength}
-              letterSpacing={0.03}
-              outlineWidth={0.02}
-              outlineColor="#FFFFFF"
-              depthOffset={-1}
-              curveRadius={-textRadius}
-              name={`door-label-text-${title.toLowerCase()}`}
-              userData={{ doorKey: title, text: title }}
-            >
-              {title}
-            </Text>
+            <DoorwayLabelText
+              title={title}
+              textRadius={textRadius}
+              arcLength={arcLength}
+            />
           </group>
         );
       })}

--- a/src/lib/scene/doorways.ts
+++ b/src/lib/scene/doorways.ts
@@ -29,7 +29,7 @@ const DOOR_NAME_LOOKUP: Partial<Record<DoorKey, string>> = {
 function calculateDoorPosition(angle: number, radius: number = DOOR_RADIUS) {
   return new THREE.Vector3(
     Math.cos(angle) * radius,
-    3.2,
+    2.5,
     Math.sin(angle) * radius,
   );
 }


### PR DESCRIPTION
## Summary
- restore curved doorway labels by applying the radius through a ref to satisfy TypeScript
- align doorway hitbox heights and camera defaults so interactions share the same Y level
- update camera animation paths to handle off-center starts and face the Archives doorway by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b9e0008488326b818095a0cb509ae