### PR TITLE
Align MuseumScene camera target with rotunda center

### DIFF
--- a/src/components/MuseumScene.tsx
+++ b/src/components/MuseumScene.tsx
@@ -39,7 +39,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
   const { camera, gl, scene } = useThree();
 
   const initialCameraPos = useRef(new THREE.Vector3(6, 2.5, 0));
-  const initialLookTarget = useRef(new THREE.Vector3(-9, 2.5, 0));
+  const initialLookTarget = useRef(new THREE.Vector3(0, 2.5, 0));
   const animationCurve = useRef<THREE.CatmullRomCurve3 | null>(null);
   const animationProgress = useRef(0);
   const animationDuration = useRef(3);
@@ -62,10 +62,10 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
     camera.position.copy(initialCameraPos.current);
     camera.lookAt(initialLookTarget.current);
 
-    if (controlsRef.current) {
-      controlsRef.current.target.copy(initialLookTarget.current);
-      controlsRef.current.update();
-    }
+      if (controlsRef.current) {
+        controlsRef.current.target.copy(initialLookTarget.current);
+        controlsRef.current.update();
+      }
   }, [camera]);
 
   useEffect(() => {
@@ -307,7 +307,7 @@ export function MuseumScene({ onDoorClick, onResetCamera, selectedRoom, onZoomCo
       <OrbitControls
         ref={controlsRef}
         enabled={!isAnimating}
-        target={[-9, 2.5, 0]}
+        target={[0, 2.5, 0]}
         enablePan={false}
         enableZoom={true}
         minDistance={0.01}


### PR DESCRIPTION
## Summary
- update the initial camera look target to aim at the rotunda center
- align the orbit controls target and animation reset logic with the new focus point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690ba3be0e4083268ead3e9458679479