### PR TITLE
Restore door ordering while sorting angles for rotunda geometry

### DIFF
--- a/src/components/RotundaGeometry.tsx
+++ b/src/components/RotundaGeometry.tsx
@@ -9,7 +9,10 @@ interface RotundaGeometryProps {
 }
 
 // 4 doorway positions at cardinal directions (sourced from shared doorway config)
-const DOORWAY_ANGLES = DOORWAYS.map((door) => door.angle);
+// Keep a sorted list of doorway angles so adjacent-door calculations remain accurate
+const DOORWAY_ANGLES = [...DOORWAYS]
+  .map((door) => door.angle)
+  .sort((a, b) => a - b);
 const DOORWAY_WIDTH = Math.PI / 6; // Width of each doorway opening (30 degrees)
 
 interface DoorwayLabelTextProps {


### PR DESCRIPTION
## Summary
- restore the doorway metadata to its original ordering so UI expectations remain intact
- sort doorway angles inside the rotunda geometry to keep wall and column calculations aligned with the 3D doors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bb25c56888326b71b7aab541243e2