### PR TITLE
Restore room activation after door zoom

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -54,14 +54,18 @@ const Index = () => {
   };
   
   const handleZoomComplete = useCallback((roomKey: string) => {
+    const door = DOORWAYS.find((entry) => entry.key === roomKey);
+    if (door) {
+      setSelectedDoor(door);
+    }
+    setActiveRoom(roomKey);
+    setShowRoomPanel(true);
+
     let path = queuedPath;
-    if (!path) {
-      const fallbackDoor = DOORWAYS.find((door) => door.key === roomKey);
-      if (fallbackDoor) {
-        const fallbackKey = fallbackDoor.shortTitle as DoorKey;
-        if (fallbackKey && DOOR_LINKS[fallbackKey]) {
-          path = DOOR_LINKS[fallbackKey];
-        }
+    if (!path && door) {
+      const fallbackKey = door.shortTitle as DoorKey;
+      if (fallbackKey && DOOR_LINKS[fallbackKey]) {
+        path = DOOR_LINKS[fallbackKey];
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure the zoom completion handler restores the active room and panel state using the resolved doorway
- keep the doorway navigation fallback path aligned with the door metadata when no queued path exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bb70a25908326af10e280b3124ed9