### PR TITLE
Add offline content pack tooling

### DIFF
--- a/docs/executive-summary.md
+++ b/docs/executive-summary.md
@@ -1,0 +1,60 @@
+# Virtual Gallery Kiosk Executive Summary
+
+## Vision & Goals
+Create a fully offline, tamper-resistant Windows 10 kiosk that immerses visitors in a 3D rotunda. Alumni, faculty, publications, and archival assets are discoverable through a touch-first interface backed by a signed, structured content pack. Annual updates arrive via USB, are validated locally, and activate with rollback safeguards—no internet connectivity is ever required.
+
+## Core Personas & Journeys
+- **Visitor:** Enter the rotunda, tap doorways (Alumni, Faculty, Publications, Archives), browse by year/role, open detailed person views with photos and metadata, and launch HTML5 flipbooks for publications or archives.
+- **Staff (Admin PIN):** Unlock an Admin Panel to import a content pack, rebuild SQLite indices and image derivatives, run integrity checks, tune kiosk settings (idle timeout, GPU fallback), and monitor device health metrics (disk, DB size, logs).
+- **IT:** Deploy and lock the kiosk using Assigned Access/Shell Launcher, manage code-signed installers and content packs, verify cryptographic signatures, enforce allowlists, and export logs while maintaining an air-gapped environment.
+
+## Offline Constraints & Experience Targets
+- Operates 100% offline: bundled fonts, JS libraries, Three.js assets, and flipbook engine; no remote calls or CDNs.
+- Performance: cold boot under 8 seconds; Three.js rotunda at 60 FPS on target hardware; SQLite FTS5 search responses under 200 ms.
+- Touch UX: ≥48 px hit targets, kiosk-friendly keyboard, kinetic scrolling, idle attract-mode, accessibility toggles, captions when provided.
+
+## Single Source of Truth (SSOT)
+- **Content Packs:** Signed zip bundles containing `manifest.json`, CSV/Parquet tables, media assets, and checksums (Ed25519 signature). Content version drives DB migrations.
+- **SQLite Runtime Store:** Canonical schema for people, cohorts, person_cohort links, photos, publications, archive items, and metadata. Photos deduplicated by SHA-256 hash with derivatives stored under `/content/derivatives`.
+- **Importer Workflow:** Validates schemas, verifies signatures, copies assets, generates thumbnails/derivatives, updates SQLite in WAL mode, rebuilds FTS indices, and stages activation with rollback capability.
+
+## Application Architecture
+- **Electron Shell:** Hosts the kiosk with React + Three.js renderer, including 3D rotunda, fallback 2D navigation, and flipbook viewer modal (local engine such as StPageFlip/turn.js).
+- **Local Services:** Typed DAOs for SQLite access, audit logging, health telemetry, and Node tooling for migrations and derivative generation.
+- **Tooling Suite:** Importer CLI (`import-pack`, `activate-staged`, `rollback`, `gen-derivatives`, `check-integrity`, `reindex-fts`) and pack builder/signing utilities.
+
+## Security & Hardening
+- Windows 10 Assigned Access/Shell Launcher, AppLocker or WDAC allowlisting, outbound network blocked, optional Wi-Fi disablement.
+- Code signing for Electron app and tooling; strict WebView confinement (no external protocols); admin PIN required for sensitive actions.
+- USB policy: read-only media for content import, no autoplay; logs rotate locally and export via PIN-guarded workflow.
+
+## Update Workflow
+1. Author CSVs/media in the content repository.
+2. Build a signed content pack with hashes and manifest.
+3. IT stages pack on approved USB and performs offline validation.
+4. Admin imports pack via kiosk UI → signature & schema verification → DB migration → integrity checks.
+5. Activate staged database atomically; rollback restores prior snapshot if any check fails.
+
+## Roadmap Phases
+- **Phase A – Foundations:** Project scaffolding, SQLite schema/migrations, FTS5 seeding, importer CLI.
+- **Phase B – SSOT & Packs:** Manifest schema, pack builder/signing, staging/rollback pipeline, integrity checks.
+- **Phase C – UI:** Three.js rotunda, alumni/faculty/publication/archive flows, instant search, performance profiling, 2D fallback.
+- **Phase D – Admin & Ops:** PIN gate, import UI with progress/logs, health dashboard, log export.
+- **Phase E – Hardening & Deploy:** MSIX/Squirrel installer, kiosk watchdog, Assigned Access/AppLocker scripts.
+- **Phase F – QA & UAT:** Synthetic dataset, soak tests, power-loss simulations, accessibility/touch QA.
+
+## Acceptance Criteria & Success Metrics
+- Kiosk boots locked down, resists tampering, and remains fully functional offline.
+- Content imports require valid signatures, pass integrity checks, and support rollback without data loss.
+- Browsing, search, flipbooks, and media playback are smooth; performance targets sustained during extended demos.
+- Admin workflows (import, diagnostics, log export) operate without network access; power interruptions do not corrupt the active database.
+
+## Data & Media Highlights
+- Cohorts cover 1980–2025 (extendable) with class president filters; person_fts virtual table enables instant search.
+- Media pipeline stores originals by SHA-256 under `/content/assets/img/<hash>.<ext>` and generates derivatives (`thumb`, `screen`, `tile`); EXIF stripped and metadata captured in DB.
+- Flipbooks ship as self-contained folders (`/assets/flipbooks/<id>/index.html`) rendered in an embedded WebView with no external URLs.
+
+## Deployment & Operations Snapshot
+- Offline installer (MSIX preferred) with code signing; updates delivered annually via content packs or installer refresh.
+- Watchdog restarts kiosk on crashes; crash logs stored locally with rotation policies.
+- Laminated runbook: boot into kiosk, authenticate via admin PIN, import signed pack, verify integrity, activate, rollback if needed, export logs for IT review.

--- a/docs/importer.md
+++ b/docs/importer.md
@@ -1,0 +1,86 @@
+# Offline Content Pack Tooling
+
+The kiosk ships with a small Node-based toolkit that can run entirely offline on the Windows kiosk workstation. The tooling
+implements the update workflow described in the executive summary: verify a signed content pack, stage it in SQLite, copy the
+hashed asset store, generate derivatives, and then promote or roll back the data file.
+
+## Directory layout
+
+The CLI assumes the default content tree lives under `./content` (matching the runtime layout used by Electron):
+
+```
+content/
+  db/
+    app.db           # active database (WAL enabled)
+    app.db.staging   # most recent staged import
+    app.db.previous  # backup snapshot from last activation
+  assets/
+    img/
+    flipbooks/
+  derivatives/
+    thumb/
+    screen/
+  logs/
+```
+
+Use the `--content-root` flag to point at another root when running on a different volume.
+
+## Commands
+
+Run the tool with `node tools/importer/index.js <command> [options]`.
+
+| Command | Purpose |
+| --- | --- |
+| `import-pack <pack.zip>` | Extract, validate, and stage a content pack into `app.db.staging`, copying images, flipbooks, and writing an audit log. |
+| `activate-staged` | Promote the staged database to active (`app.db`), snapshotting the current database to `app.db.previous`. |
+| `rollback` | Restore the previous snapshot if an activation fails. |
+| `gen-derivatives` | Create or refresh the thumbnail/screen image derivatives for every known photo. |
+| `check-integrity` | Run consistency checks against the database and filesystem. |
+| `reindex-fts` | Rebuild the `person_fts` FTS5 index. |
+
+Every command accepts `--content-root <path>` to override the default tree. Additional command specific flags include:
+
+- `import-pack`
+  - `--verify` and `--public-key <path>` to require manifest signature validation (Ed25519 public key in PEM or base64 form).
+  - `--skip-derivatives` to avoid running the derivative pass during import.
+  - `--force` to force derivative regeneration.
+- `check-integrity`
+  - `--level strict` enables duplicate slug/hash detection.
+  - `--staged` checks the staged database instead of the active database.
+- `gen-derivatives`
+  - `--force` regenerates derivatives even if files already exist.
+
+## Import flow
+
+1. Copy the signed content pack ZIP onto the kiosk and run:
+   ```bash
+   node tools/importer/index.js import-pack D:\\packs\\alumni-2025.zip --verify --public-key keys\\content-team.pub
+   ```
+2. Review the generated log file under `content/logs/` to confirm row counts and hashes.
+3. Promote the staged database once validation passes:
+   ```bash
+   node tools/importer/index.js activate-staged
+   ```
+4. Run integrity checks in strict mode to confirm there are no missing assets:
+   ```bash
+   node tools/importer/index.js check-integrity --level strict
+   ```
+5. If anything fails after activation, revert instantly:
+   ```bash
+   node tools/importer/index.js rollback
+   ```
+
+The derivative generator will use ImageMagick (`magick` or `convert`) when available; otherwise it will fall back to copying the
+source images into the derivative folders so the kiosk UI always has assets to load.
+
+## Database schema
+
+The importer initialises the SQLite database with the canonical tables described in the product specification. Every import wipes
+and re-populates the tables inside a single transaction, then repopulates the `person_fts` virtual table. The schema lives in
+`tools/importer/lib/sqlite.js`.
+
+## Extending the toolchain
+
+The CLI is intentionally modular. Each command lives in `tools/importer/commands/` and only relies on Node built-ins plus
+`sqlite3` and `unzip` binaries that ship with Windows Subsystem for Linux or standard admin images. Add new commands or expand the
+existing ones by composing helpers in `tools/importer/lib/`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "kiosk": "node tools/importer/index.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/tools/importer/commands/activate-staged.js
+++ b/tools/importer/commands/activate-staged.js
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import { rename } from 'node:fs/promises';
+import { resolveContentPaths, DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { pathExists, removePath } from '../lib/fs.js';
+import { logInfo, logSuccess } from '../lib/logger.js';
+
+export async function activateStaged(options) {
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const paths = resolveContentPaths(contentRoot);
+
+  const stagedDb = options.stagedDb ? path.resolve(options.stagedDb) : paths.stagedDb;
+  const activeDb = options.activeDb ? path.resolve(options.activeDb) : paths.activeDb;
+  const backupDb = path.join(path.dirname(activeDb), 'app.db.previous');
+
+  if (!(await pathExists(stagedDb))) {
+    throw new Error(`Staged database not found at ${stagedDb}`);
+  }
+
+  if (await pathExists(backupDb)) {
+    await removePath(backupDb);
+  }
+
+  if (await pathExists(activeDb)) {
+    await rename(activeDb, backupDb);
+    await removePath(`${activeDb}-wal`);
+    await removePath(`${activeDb}-shm`);
+    logInfo(`Active database backed up to ${backupDb}`);
+  }
+
+  await rename(stagedDb, activeDb);
+  await removePath(`${stagedDb}-wal`);
+  await removePath(`${stagedDb}-shm`);
+  logSuccess(`Activated staged database at ${activeDb}`);
+}

--- a/tools/importer/commands/check-integrity.js
+++ b/tools/importer/commands/check-integrity.js
@@ -1,0 +1,117 @@
+import path from 'node:path';
+import { resolveContentPaths, DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { runQuery } from '../lib/sqlite.js';
+import { pathExists } from '../lib/fs.js';
+import { logSuccess, logWarn } from '../lib/logger.js';
+
+export async function checkIntegrity(options) {
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const level = typeof options.level === 'string' ? options.level.toLowerCase() : 'basic';
+  const paths = resolveContentPaths(contentRoot);
+  const useStaged = options.staged === true || options.target === 'staged';
+  const dbPath = useStaged ? (options.stagedDb ? path.resolve(options.stagedDb) : paths.stagedDb) : (options.activeDb ? path.resolve(options.activeDb) : paths.activeDb);
+
+  if (!(await pathExists(dbPath))) {
+    throw new Error(`Database not found at ${dbPath}`);
+  }
+
+  const report = {
+    database: dbPath,
+    level,
+    people: {},
+    cohorts: {},
+    photos: {},
+    flipbooks: {},
+    meta: {},
+    issues: [],
+  };
+
+  report.people.total = await scalar(dbPath, 'SELECT COUNT(*) as value FROM person;');
+  const missingDisplay = await runQuery(dbPath, "SELECT id FROM person WHERE display_name IS NULL OR TRIM(display_name) = '' LIMIT 50;");
+  if (missingDisplay.length > 0) {
+    report.people.missingDisplayName = missingDisplay.map((row) => row.id);
+    report.issues.push('Persons missing display_name');
+  }
+
+  report.cohorts.total = await scalar(dbPath, 'SELECT COUNT(*) as value FROM cohort;');
+  const orphanCohorts = await runQuery(dbPath, `SELECT pc.person_id, pc.cohort_id FROM person_cohort pc
+    LEFT JOIN person p ON p.id = pc.person_id
+    LEFT JOIN cohort c ON c.id = pc.cohort_id
+    WHERE p.id IS NULL OR c.id IS NULL
+    LIMIT 50;`);
+  if (orphanCohorts.length > 0) {
+    report.cohorts.orphans = orphanCohorts;
+    report.issues.push('Person-cohort relations referencing missing rows');
+  }
+
+  const photos = await runQuery(dbPath, 'SELECT id, sha256, ext FROM photo;');
+  const missingPhotos = [];
+  for (const row of photos) {
+    if (!row.sha256) {
+      missingPhotos.push({ id: row.id, reason: 'missing sha256' });
+      continue;
+    }
+    const ext = row.ext ? row.ext.replace('.', '') : 'jpg';
+    const filePath = path.join(paths.imagesDir, `${row.sha256}.${ext}`);
+    if (!(await pathExists(filePath))) {
+      missingPhotos.push({ id: row.id, sha256: row.sha256, expected: filePath });
+    }
+  }
+  if (missingPhotos.length > 0) {
+    report.photos.missingFiles = missingPhotos;
+    report.issues.push('Missing image assets on disk');
+  }
+  report.photos.total = photos.length;
+
+  const flipbookRefs = await runQuery(dbPath, `SELECT flipbook_manifest_path AS path FROM publication WHERE flipbook_manifest_path IS NOT NULL
+    UNION
+    SELECT flipbook_manifest_path AS path FROM archive_item WHERE flipbook_manifest_path IS NOT NULL;`);
+  const missingFlipbooks = [];
+  for (const row of flipbookRefs) {
+    const manifestPath = typeof row.path === 'string' ? row.path.trim() : '';
+    if (!manifestPath) continue;
+    const relative = manifestPath.replace(/^\//, '');
+    const filePath = path.join(contentRoot, relative);
+    if (!(await pathExists(filePath))) {
+      missingFlipbooks.push(filePath);
+    }
+  }
+  if (missingFlipbooks.length > 0) {
+    report.flipbooks.missingManifests = missingFlipbooks;
+    report.issues.push('Missing flipbook manifests');
+  }
+
+  const metaRows = await runQuery(dbPath, 'SELECT key, value FROM meta;');
+  report.meta.entries = Object.fromEntries(metaRows.map((row) => [row.key, row.value]));
+
+  if (level === 'strict') {
+    const duplicatePersonSlugs = await runQuery(dbPath, 'SELECT slug, COUNT(*) as count FROM person GROUP BY slug HAVING count > 1;');
+    if (duplicatePersonSlugs.length > 0) {
+      report.people.duplicateSlugs = duplicatePersonSlugs;
+      report.issues.push('Duplicate person slugs detected');
+    }
+    const duplicatePhotos = await runQuery(dbPath, 'SELECT sha256, COUNT(*) as count FROM photo GROUP BY sha256 HAVING count > 1;');
+    if (duplicatePhotos.length > 0) {
+      report.photos.duplicateHashes = duplicatePhotos;
+      report.issues.push('Duplicate photo sha256 entries');
+    }
+  }
+
+  if (report.issues.length === 0) {
+    logSuccess('Integrity checks passed.');
+  } else {
+    logWarn(`Integrity issues found: ${report.issues.join(', ')}`);
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+async function scalar(databasePath, query) {
+  const rows = await runQuery(databasePath, query);
+  if (!rows || rows.length === 0) {
+    return 0;
+  }
+  const value = rows[0].value;
+  const numberValue = typeof value === 'number' ? value : Number.parseInt(value, 10);
+  return Number.isNaN(numberValue) ? 0 : numberValue;
+}

--- a/tools/importer/commands/gen-derivatives.js
+++ b/tools/importer/commands/gen-derivatives.js
@@ -1,0 +1,115 @@
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { copyFile } from 'node:fs/promises';
+import { ensureDir, listFilesRecursive, pathExists } from '../lib/fs.js';
+import { resolveContentPaths, DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { logInfo, logSuccess, logWarn } from '../lib/logger.js';
+
+export async function generateDerivatives(options) {
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const paths = resolveContentPaths(contentRoot);
+  await ensureDir(paths.imagesDir);
+  await ensureDir(paths.thumbDir);
+  await ensureDir(paths.screenDir);
+
+  await generateDerivativesForImages({
+    imagesDir: paths.imagesDir,
+    thumbDir: paths.thumbDir,
+    screenDir: paths.screenDir,
+    force: options.force === true,
+  });
+
+  logSuccess('Derivative generation complete.');
+}
+
+export async function generateDerivativesForImages({ imagesDir, thumbDir, screenDir, force = false }) {
+  const files = await listFilesRecursive(imagesDir);
+  if (files.length === 0) {
+    logWarn('No images available for derivative generation.');
+    return;
+  }
+
+  const magickCommand = await detectImageMagick();
+  if (!magickCommand) {
+    logWarn('ImageMagick not found. Derivatives will be simple copies of originals.');
+  } else {
+    logInfo(`Using ${magickCommand} for image processing.`);
+  }
+
+  let processed = 0;
+  for (const relative of files) {
+    if (!relative.match(/\.(jpg|jpeg|png|webp)$/i)) {
+      continue;
+    }
+    const source = path.join(imagesDir, relative);
+    const thumbTarget = path.join(thumbDir, relative);
+    const screenTarget = path.join(screenDir, relative);
+    await ensureDir(path.dirname(thumbTarget));
+    await ensureDir(path.dirname(screenTarget));
+
+    const needsThumb = force || !(await pathExists(thumbTarget));
+    const needsScreen = force || !(await pathExists(screenTarget));
+
+    if (needsThumb) {
+      await createDerivative({ command: magickCommand, source, target: thumbTarget, size: '256x256', crop: true });
+    }
+    if (needsScreen) {
+      await createDerivative({ command: magickCommand, source, target: screenTarget, size: '1600x1600', crop: false });
+    }
+    processed += needsThumb || needsScreen ? 1 : 0;
+  }
+  logInfo(`Derivatives processed for ${processed} source images.`);
+}
+
+async function createDerivative({ command, source, target, size, crop }) {
+  if (!command) {
+    await copyFile(source, target);
+    return;
+  }
+  const args = crop
+    ? [source, '-auto-orient', '-resize', `${size}^`, '-gravity', 'center', '-extent', size, target]
+    : [source, '-auto-orient', '-resize', `${size}>`, target];
+  await runCommand(command, args, source);
+}
+
+async function detectImageMagick() {
+  if (await commandExists('magick')) {
+    return 'magick';
+  }
+  if (await commandExists('convert')) {
+    return 'convert';
+  }
+  return null;
+}
+
+function commandExists(command) {
+  return new Promise((resolve) => {
+    const locator = process.platform === 'win32' ? 'where' : 'which';
+    const child = spawn(locator, [command]);
+    child.on('close', (code) => resolve(code === 0));
+    child.on('error', () => resolve(false));
+  });
+}
+
+function runCommand(command, args, source) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        logWarn(`Derivative generation failed for ${source}: ${stderr}`);
+        reject(new Error(stderr || `${command} exited with ${code}`));
+      } else {
+        resolve();
+      }
+    });
+    child.on('error', (error) => {
+      logWarn(`Unable to launch ${command}: ${error.message}`);
+      reject(error);
+    });
+  }).catch(async () => {
+    await copyFile(source, args[args.length - 1]);
+  });
+}

--- a/tools/importer/commands/import-pack.js
+++ b/tools/importer/commands/import-pack.js
@@ -1,0 +1,184 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { createTempDir, extractZip } from '../lib/archive.js';
+import { ensureContentLayout } from '../lib/paths.js';
+import { loadManifest, ensureSemverCompatible, verifyManifestHash, verifyManifestSignature } from '../lib/manifest.js';
+import { loadTable } from '../lib/normalise.js';
+import { initialiseDatabase, runSqliteScript, buildInsert, escapeValue } from '../lib/sqlite.js';
+import { removePath, writeJson } from '../lib/fs.js';
+import { syncImageAssets, syncFlipbooks } from '../lib/assets.js';
+import { logInfo, logSuccess } from '../lib/logger.js';
+import { hashFileSha256 } from '../lib/hash.js';
+import { DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { generateDerivativesForImages } from './gen-derivatives.js';
+
+const require = createRequire(import.meta.url);
+const { version: APP_VERSION = '0.0.0' } = require('../../../package.json');
+
+export async function importPack(options) {
+  const packPath = options._?.[0];
+  if (!packPath) {
+    throw new Error('Specify a pack file: import-pack <path-to-pack.zip>');
+  }
+
+  const resolvedPackPath = path.resolve(packPath);
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const skipDerivatives = options.skipDerivatives === true;
+  const requireVerification = options.verify === true;
+  const forceDerivatives = options.force === true;
+
+  logInfo(`Importing content pack ${resolvedPackPath}`);
+
+  const tempDir = await createTempDir();
+  let packSha256 = null;
+
+  try {
+    logInfo(`Extracting pack to ${tempDir}`);
+    await extractZip(resolvedPackPath, tempDir);
+
+    const { manifest, raw } = await loadManifest(tempDir);
+    ensureSemverCompatible(manifest, APP_VERSION);
+
+    const manifestHash = await verifyManifestHash(tempDir, raw);
+    let signatureBase64 = null;
+
+    if (requireVerification) {
+      const publicKeyPath = options.publicKey ? path.resolve(options.publicKey) : null;
+      if (!publicKeyPath) {
+        throw new Error('Signature verification requested but --public-key was not provided.');
+      }
+      const publicKeyBuffer = await readFile(publicKeyPath);
+      const signature = await verifyManifestSignature(tempDir, raw, normalisePublicKey(publicKeyBuffer));
+      signatureBase64 = Buffer.from(signature).toString('base64');
+      logInfo('Signature verification passed.');
+    }
+
+    const tables = await loadAllTables(manifest, tempDir);
+
+    const paths = await ensureContentLayout(contentRoot);
+    const stagedDbPath = options.stagedDb ? path.resolve(options.stagedDb) : paths.stagedDb;
+    await removePath(stagedDbPath);
+    await removePath(`${stagedDbPath}-wal`);
+    await removePath(`${stagedDbPath}-shm`);
+    await initialiseDatabase(stagedDbPath);
+
+    packSha256 = await hashFileSha256(resolvedPackPath);
+    const statements = buildStatementsForImport(tables, manifest, { manifestHash, signatureBase64, packSha256 });
+    await runSqliteScript(stagedDbPath, statements);
+    logInfo('Database staged with imported content.');
+
+    const imageSourceDir = path.join(tempDir, manifest.assets.images.path.replace(/^\//, ''));
+    await syncImageAssets(imageSourceDir, paths.imagesDir);
+
+    const flipbookSourceDir = path.join(tempDir, manifest.assets.flipbooks.path.replace(/^\//, ''));
+    await syncFlipbooks(flipbookSourceDir, paths.flipbooksDir);
+
+    if (!skipDerivatives) {
+      await generateDerivativesForImages({
+        imagesDir: paths.imagesDir,
+        thumbDir: paths.thumbDir,
+        screenDir: paths.screenDir,
+        force: forceDerivatives,
+      });
+    } else {
+      logInfo('Skipping derivative generation as requested.');
+    }
+
+    const logPath = path.join(paths.logsDir, `import-${Date.now()}.json`);
+    const logPayload = {
+      pack_id: manifest.pack_id,
+      manifest_hash: manifestHash,
+      signature: signatureBase64,
+      imported_at: new Date().toISOString(),
+      tables: Object.fromEntries(Object.entries(tables).map(([key, value]) => [key, value.length])),
+      staged_db: stagedDbPath,
+      content_root: contentRoot,
+      pack_sha256: packSha256,
+    };
+    await writeJson(logPath, logPayload);
+    logSuccess(`Import completed. Review ${logPath} and run activate-staged when ready.`);
+  } finally {
+    await removePath(tempDir);
+  }
+}
+
+function normalisePublicKey(buffer) {
+  const trimmed = buffer.toString('utf8').trim();
+  if (trimmed.includes('-----BEGIN')) {
+    return buffer;
+  }
+  const cleaned = trimmed.replace(/[^A-Za-z0-9+/=]/g, '');
+  return Buffer.from(cleaned, 'base64');
+}
+
+async function loadAllTables(manifest, tempDir) {
+  const tableNames = ['person', 'cohort', 'person_cohort', 'photo', 'person_photo', 'publication', 'archive_item'];
+  const entries = await Promise.all(tableNames.map(async (tableName) => {
+    const rows = await loadTable(manifest, tempDir, tableName);
+    return [tableName, rows];
+  }));
+  return Object.fromEntries(entries);
+}
+
+function buildStatementsForImport(tables, manifest, context) {
+  const statements = [
+    'DELETE FROM person;',
+    'DELETE FROM cohort;',
+    'DELETE FROM person_cohort;',
+    'DELETE FROM photo;',
+    'DELETE FROM person_photo;',
+    'DELETE FROM publication;',
+    'DELETE FROM archive_item;',
+    'DELETE FROM meta;',
+    'DELETE FROM person_fts;',
+  ];
+
+  statements.push(
+    ...buildInsert(
+      'person',
+      ['id', 'first_name', 'middle_name', 'last_name', 'suffix', 'display_name', 'slug', 'bio', 'is_faculty', 'created_at', 'updated_at'],
+      tables.person,
+    ),
+  );
+
+  statements.push(
+    ...buildInsert('cohort', ['id', 'year', 'label'], tables.cohort),
+  );
+
+  statements.push(
+    ...buildInsert('person_cohort', ['person_id', 'cohort_id', 'is_class_president', 'homeroom', 'notes'], tables.person_cohort),
+  );
+
+  statements.push(
+    ...buildInsert('photo', ['id', 'sha256', 'ext', 'width', 'height', 'bytes', 'caption', 'credit', 'created_at'], tables.photo),
+  );
+
+  statements.push(
+    ...buildInsert('person_photo', ['person_id', 'photo_id', 'kind', 'is_primary'], tables.person_photo),
+  );
+
+  statements.push(
+    ...buildInsert('publication', ['id', 'title', 'issue_date', 'volume', 'number', 'slug', 'cover_photo_id', 'flipbook_manifest_path'], tables.publication),
+  );
+
+  statements.push(
+    ...buildInsert('archive_item', ['id', 'title', 'year', 'kind', 'photo_id', 'flipbook_manifest_path', 'description'], tables.archive_item),
+  );
+
+  statements.push(`INSERT INTO meta (key, value) VALUES ('content_version', ${escapeValue(String(manifest.content_version))});`);
+  statements.push(`INSERT INTO meta (key, value) VALUES ('pack_id', ${escapeValue(manifest.pack_id)});`);
+  statements.push(`INSERT INTO meta (key, value) VALUES ('manifest_hash', ${escapeValue(context.manifestHash)});`);
+  if (context.packSha256) {
+    statements.push(`INSERT INTO meta (key, value) VALUES ('pack_sha256', ${escapeValue(context.packSha256)});`);
+  }
+  if (context.signatureBase64) {
+    statements.push(`INSERT INTO meta (key, value) VALUES ('pack_signature', ${escapeValue(context.signatureBase64)});`);
+  }
+  statements.push(`INSERT INTO meta (key, value) VALUES ('imported_at', ${escapeValue(new Date().toISOString())});`);
+
+  statements.push(`INSERT INTO person_fts(rowid, display_name, last_name, first_name)
+    SELECT id, display_name, last_name, first_name FROM person;`);
+
+  return statements;
+}

--- a/tools/importer/commands/reindex-fts.js
+++ b/tools/importer/commands/reindex-fts.js
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { resolveContentPaths, DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { pathExists } from '../lib/fs.js';
+import { runSqliteScript } from '../lib/sqlite.js';
+import { logSuccess } from '../lib/logger.js';
+
+export async function reindexFts(options) {
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const paths = resolveContentPaths(contentRoot);
+  const dbPath = options.activeDb ? path.resolve(options.activeDb) : paths.activeDb;
+
+  if (!(await pathExists(dbPath))) {
+    throw new Error(`Database not found at ${dbPath}`);
+  }
+
+  const statements = [
+    'DELETE FROM person_fts;',
+    `INSERT INTO person_fts(rowid, display_name, last_name, first_name)
+      SELECT id, display_name, last_name, first_name FROM person;`,
+  ];
+
+  await runSqliteScript(dbPath, statements);
+  logSuccess('FTS index refreshed.');
+}

--- a/tools/importer/commands/rollback.js
+++ b/tools/importer/commands/rollback.js
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import { rename } from 'node:fs/promises';
+import { resolveContentPaths, DEFAULT_CONTENT_ROOT } from '../lib/paths.js';
+import { pathExists, removePath } from '../lib/fs.js';
+import { logInfo, logSuccess } from '../lib/logger.js';
+
+export async function rollbackActive(options) {
+  const contentRoot = options.contentRoot ? path.resolve(options.contentRoot) : DEFAULT_CONTENT_ROOT;
+  const paths = resolveContentPaths(contentRoot);
+
+  const activeDb = options.activeDb ? path.resolve(options.activeDb) : paths.activeDb;
+  const backupDb = path.join(path.dirname(activeDb), 'app.db.previous');
+
+  if (!(await pathExists(backupDb))) {
+    throw new Error(`No backup database found at ${backupDb}`);
+  }
+
+  const failedDb = `${activeDb}.failed-${Date.now()}`;
+  if (await pathExists(activeDb)) {
+    await rename(activeDb, failedDb);
+    await removePath(`${activeDb}-wal`);
+    await removePath(`${activeDb}-shm`);
+    logInfo(`Current active database moved to ${failedDb}`);
+  }
+
+  await rename(backupDb, activeDb);
+  await removePath(`${backupDb}-wal`);
+  await removePath(`${backupDb}-shm`);
+  logSuccess(`Rollback complete. Active database restored from ${backupDb}`);
+}

--- a/tools/importer/index.js
+++ b/tools/importer/index.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { parseArgs } from './lib/args.js';
+import { importPack } from './commands/import-pack.js';
+import { activateStaged } from './commands/activate-staged.js';
+import { rollbackActive } from './commands/rollback.js';
+import { generateDerivatives } from './commands/gen-derivatives.js';
+import { checkIntegrity } from './commands/check-integrity.js';
+import { reindexFts } from './commands/reindex-fts.js';
+import { logError } from './lib/logger.js';
+
+async function main() {
+  const { command, options } = parseArgs(process.argv.slice(2));
+
+  try {
+    switch (command) {
+      case 'import-pack':
+        await importPack(options);
+        break;
+      case 'activate-staged':
+        await activateStaged(options);
+        break;
+      case 'rollback':
+        await rollbackActive(options);
+        break;
+      case 'gen-derivatives':
+        await generateDerivatives(options);
+        break;
+      case 'check-integrity':
+        await checkIntegrity(options);
+        break;
+      case 'reindex-fts':
+        await reindexFts(options);
+        break;
+      case 'help':
+      case undefined:
+        printHelp();
+        break;
+      default:
+        logError(`Unknown command: ${command}`);
+        printHelp();
+        process.exitCode = 1;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logError(message);
+    if (error instanceof Error && error.stack) {
+      logError(error.stack);
+    }
+    process.exitCode = 1;
+  }
+}
+
+function printHelp() {
+  console.log(`Offline Kiosk Tooling\n\n` +
+    `Usage: node tools/importer/index.js <command> [options]\n\n` +
+    `Commands:\n` +
+    `  import-pack <pack.zip>   Verify and stage a content pack\n` +
+    `  activate-staged          Promote the staged database and snapshot previous\n` +
+    `  rollback                 Restore the previous active database snapshot\n` +
+    `  gen-derivatives          Generate image derivatives for all known photos\n` +
+    `  check-integrity          Run integrity checks against the database\n` +
+    `  reindex-fts              Rebuild the FTS5 search index\n` +
+    `  help                     Show this message\n` +
+    `\nOptions:\n` +
+    `  --content-root <path>    Override the kiosk content directory (default ./content)\n` +
+    `  --verify                 Require signature and hash verification during import\n` +
+    `  --public-key <path>      Path to Ed25519 public key for signature verification\n` +
+    `  --staged-db <path>       Override the staged database path\n` +
+    `  --active-db <path>       Override the active database path\n` +
+    `  --skip-derivatives       Skip derivative generation during import\n` +
+    `  --force                  Force regeneration for derivatives\n` +
+    `  --level <basic|strict>   Integrity check strictness (default basic)\n`);
+}
+
+await main();

--- a/tools/importer/lib/archive.js
+++ b/tools/importer/lib/archive.js
@@ -1,0 +1,24 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+
+export async function createTempDir(prefix = 'kiosk-pack-') {
+  const base = path.join(tmpdir(), prefix);
+  return mkdtemp(base);
+}
+
+export async function extractZip(zipPath, destination) {
+  await new Promise((resolve, reject) => {
+    const child = execFile('unzip', ['-q', zipPath, '-d', destination], (error) => {
+      if (error) {
+        reject(new Error(`Failed to extract ${zipPath}: ${error.message}`));
+      } else {
+        resolve();
+      }
+    });
+    child.on('error', (error) => {
+      reject(new Error(`Unable to launch unzip: ${error.message}`));
+    });
+  });
+}

--- a/tools/importer/lib/args.js
+++ b/tools/importer/lib/args.js
@@ -1,0 +1,40 @@
+export function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const options = { _: [] };
+  let index = 0;
+  while (index < rest.length) {
+    const token = rest[index];
+    if (token.startsWith('--')) {
+      const [flag, valueFromEquals] = token.slice(2).split('=', 2);
+      if (!flag) {
+        index += 1;
+        continue;
+      }
+      let value = valueFromEquals;
+      if (value === undefined) {
+        const next = rest[index + 1];
+        if (next && !next.startsWith('--')) {
+          value = next;
+          index += 1;
+        } else {
+          value = 'true';
+        }
+      }
+      options[flag.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = normaliseValue(value);
+    } else {
+      options._.push(token);
+    }
+    index += 1;
+  }
+  return { command, options };
+}
+
+function normaliseValue(value) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  const asNumber = Number(value);
+  if (!Number.isNaN(asNumber) && value.trim() !== '') {
+    return asNumber;
+  }
+  return value;
+}

--- a/tools/importer/lib/assets.js
+++ b/tools/importer/lib/assets.js
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { stat, copyFile, cp } from 'node:fs/promises';
+import { ensureDir, listFilesRecursive } from './fs.js';
+import { hashFileSha256 } from './hash.js';
+import { logInfo, logWarn } from './logger.js';
+
+export async function syncImageAssets(sourceDir, targetDir) {
+  await ensureDir(targetDir);
+  const files = await listFilesRecursive(sourceDir);
+  let copied = 0;
+  for (const relativePath of files) {
+    const filename = path.basename(relativePath);
+    const match = filename.match(/^([a-f0-9]{64})\.(\w+)$/);
+    if (!match) {
+      logWarn(`Skipping unexpected image file name: ${filename}`);
+      continue;
+    }
+    const [_, hash] = match;
+    const absoluteSource = path.join(sourceDir, relativePath);
+    const computed = await hashFileSha256(absoluteSource);
+    if (computed !== hash) {
+      throw new Error(`Hash mismatch for ${filename}: expected ${hash} actual ${computed}`);
+    }
+    const destination = path.join(targetDir, relativePath);
+    await ensureDir(path.dirname(destination));
+    await copyFile(absoluteSource, destination);
+    copied += 1;
+  }
+  logInfo(`Synced ${copied} image assets.`);
+}
+
+export async function syncFlipbooks(sourceDir, targetDir) {
+  await ensureDir(targetDir);
+  const stats = await stat(sourceDir).catch(() => null);
+  if (!stats) {
+    logWarn('No flipbook assets found in pack.');
+    return;
+  }
+  await cp(sourceDir, targetDir, { recursive: true, force: true });
+  logInfo('Flipbook assets updated.');
+}

--- a/tools/importer/lib/csv.js
+++ b/tools/importer/lib/csv.js
@@ -1,0 +1,69 @@
+export function parseCsv(content) {
+  const rows = [];
+  const headers = [];
+  const source = normaliseLineEndings(content);
+  const values = [];
+  let current = '';
+  let inQuotes = false;
+
+  const pushValue = () => {
+    values.push(current);
+    current = '';
+  };
+
+  const pushRow = () => {
+    rows.push(values.slice());
+    values.length = 0;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '"') {
+      const next = source[index + 1];
+      if (inQuotes && next === '"') {
+        current += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      pushValue();
+    } else if (char === '\n' && !inQuotes) {
+      pushValue();
+      pushRow();
+    } else {
+      current += char;
+    }
+  }
+  if (current.length > 0 || values.length > 0) {
+    pushValue();
+    pushRow();
+  }
+
+  if (rows.length === 0) {
+    return { headers: [], records: [] };
+  }
+
+  rows[0].forEach((value, index) => {
+    const clean = value.trim();
+    headers[index] = clean;
+  });
+
+  const records = rows.slice(1).map((row) => {
+    const record = {};
+    headers.forEach((header, index) => {
+      if (!header) {
+        return;
+      }
+      record[header] = row[index] ?? '';
+    });
+    return record;
+  }).filter((record) => Object.values(record).some((value) => value !== ''));
+
+  return { headers, records };
+}
+
+function normaliseLineEndings(value) {
+  const noBom = value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+  return noBom.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}

--- a/tools/importer/lib/fs.js
+++ b/tools/importer/lib/fs.js
@@ -1,0 +1,66 @@
+import { mkdir, stat, rm, writeFile, readFile, readdir, copyFile, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+
+export async function ensureDir(dirPath) {
+  await mkdir(dirPath, { recursive: true });
+}
+
+export async function pathExists(targetPath) {
+  try {
+    await access(targetPath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function removePath(targetPath) {
+  await rm(targetPath, { recursive: true, force: true });
+}
+
+export async function readJson(filePath) {
+  const content = await readFile(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+export async function writeJson(filePath, data) {
+  const payload = JSON.stringify(data, null, 2);
+  await writeFile(filePath, payload, 'utf8');
+}
+
+export async function listFilesRecursive(directory) {
+  const result = [];
+  const queue = [''];
+  while (queue.length > 0) {
+    const relative = queue.shift();
+    const dirPath = relative ? path.join(directory, relative) : directory;
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryRelative = relative ? path.join(relative, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        queue.push(entryRelative);
+      } else if (entry.isFile()) {
+        result.push(entryRelative);
+      }
+    }
+  }
+  return result;
+}
+
+export async function copyFileIfChanged(source, target) {
+  try {
+    const [sourceStat, targetStat] = await Promise.all([
+      stat(source),
+      stat(target).catch(() => null),
+    ]);
+    if (targetStat && targetStat.size === sourceStat.size && targetStat.mtimeMs >= sourceStat.mtimeMs) {
+      return false;
+    }
+  } catch {
+    // ignore stat errors, fallback to copy
+  }
+  await ensureDir(path.dirname(target));
+  await copyFile(source, target);
+  return true;
+}

--- a/tools/importer/lib/hash.js
+++ b/tools/importer/lib/hash.js
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+export async function hashFileSha256(filePath) {
+  const buffer = await readFile(filePath);
+  const hash = createHash('sha256');
+  hash.update(buffer);
+  return hash.digest('hex');
+}
+
+export function hashBufferSha256(buffer) {
+  const hash = createHash('sha256');
+  hash.update(buffer);
+  return hash.digest('hex');
+}

--- a/tools/importer/lib/logger.js
+++ b/tools/importer/lib/logger.js
@@ -1,0 +1,22 @@
+const LEVELS = {
+  info: 'INFO',
+  warn: 'WARN',
+  error: 'ERROR',
+  success: 'OK',
+};
+
+export function logInfo(message) {
+  console.log(`[${LEVELS.info}] ${message}`);
+}
+
+export function logWarn(message) {
+  console.warn(`[${LEVELS.warn}] ${message}`);
+}
+
+export function logError(message) {
+  console.error(`[${LEVELS.error}] ${message}`);
+}
+
+export function logSuccess(message) {
+  console.log(`[${LEVELS.success}] ${message}`);
+}

--- a/tools/importer/lib/manifest.js
+++ b/tools/importer/lib/manifest.js
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod';
+import { hashBufferSha256 } from './hash.js';
+
+const TableSchema = z.object({
+  name: z.string(),
+  format: z.enum(['csv', 'parquet']).default('csv'),
+  path: z.string(),
+  hash: z.string().optional(),
+});
+
+const ManifestSchema = z.object({
+  pack_id: z.string(),
+  content_version: z.number(),
+  created_utc: z.string(),
+  tables: z.array(TableSchema),
+  assets: z.object({
+    images: z.object({
+      count: z.number().optional(),
+      path: z.string(),
+    }),
+    flipbooks: z.object({
+      count: z.number().optional(),
+      path: z.string(),
+    }),
+  }),
+  compat: z.object({
+    min_app_semver: z.string(),
+  }).optional(),
+});
+
+export async function loadManifest(rootDir) {
+  const manifestPath = path.join(rootDir, 'manifest.json');
+  const raw = await readFile(manifestPath);
+  const manifest = ManifestSchema.parse(JSON.parse(raw.toString('utf8')));
+  return { manifest, raw };
+}
+
+export function findTable(manifest, tableName) {
+  return manifest.tables.find((table) => table.name === tableName);
+}
+
+export function ensureSemverCompatible(manifest, currentSemver) {
+  if (!manifest.compat?.min_app_semver) {
+    return;
+  }
+  const min = manifest.compat.min_app_semver;
+  if (!isSemverSatisfied(currentSemver, min)) {
+    throw new Error(`Pack requires app version >= ${min}, current ${currentSemver}`);
+  }
+}
+
+function isSemverSatisfied(current, minimum) {
+  const currentParts = current.split('.').map((value) => Number.parseInt(value, 10));
+  const minParts = minimum.split('.').map((value) => Number.parseInt(value, 10));
+  for (let index = 0; index < Math.max(currentParts.length, minParts.length); index += 1) {
+    const cur = currentParts[index] ?? 0;
+    const min = minParts[index] ?? 0;
+    if (cur > min) return true;
+    if (cur < min) return false;
+  }
+  return true;
+}
+
+export async function verifyManifestHash(rootDir, rawManifest) {
+  const checksumPath = path.join(rootDir, 'checksums', 'manifest.sha256');
+  const checksumContent = await readFile(checksumPath, 'utf8');
+  const expectedHash = checksumContent.trim().split(/\s+/)[0];
+  const actualHash = hashBufferSha256(rawManifest);
+  if (expectedHash && actualHash !== expectedHash) {
+    throw new Error(`Manifest hash mismatch: expected ${expectedHash} received ${actualHash}`);
+  }
+  return actualHash;
+}
+
+export async function verifyManifestSignature(rootDir, rawManifest, publicKeyBuffer) {
+  const signaturePath = path.join(rootDir, 'signature.sig');
+  const signature = await readFile(signaturePath);
+  const { subtle } = globalThis.crypto ?? await import('node:crypto').then((module) => module.webcrypto);
+  const key = await subtle.importKey(
+    'raw',
+    publicKeyBuffer,
+    { name: 'Ed25519' },
+    false,
+    ['verify']
+  );
+  const ok = await subtle.verify('Ed25519', key, signature, rawManifest);
+  if (!ok) {
+    throw new Error('Manifest signature verification failed.');
+  }
+  return signature;
+}

--- a/tools/importer/lib/normalise.js
+++ b/tools/importer/lib/normalise.js
@@ -1,0 +1,172 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { parseCsv } from './csv.js';
+import { findTable } from './manifest.js';
+
+const TABLE_NORMALISERS = {
+  person: normalisePerson,
+  cohort: normaliseCohort,
+  person_cohort: normalisePersonCohort,
+  photo: normalisePhoto,
+  person_photo: normalisePersonPhoto,
+  publication: normalisePublication,
+  archive_item: normaliseArchiveItem,
+};
+
+export async function loadTable(manifest, rootDir, tableName) {
+  const tableEntry = findTable(manifest, tableName);
+  if (!tableEntry) {
+    return [];
+  }
+  const filePath = path.join(rootDir, tableEntry.path.replace(/^\//, ''));
+  let raw;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(`Unable to read ${tableName} table at ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const { records } = parseCsv(raw);
+  const normaliser = TABLE_NORMALISERS[tableName];
+  if (!normaliser) {
+    return records;
+  }
+  return records.map(normaliser).filter(Boolean);
+}
+
+function emptyToNull(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return null;
+  }
+  return trimmed;
+}
+
+function parseBoolean(value) {
+  const trimmed = String(value ?? '').trim().toLowerCase();
+  if (trimmed === '1' || trimmed === 'true' || trimmed === 'yes') {
+    return true;
+  }
+  if (trimmed === '0' || trimmed === 'false' || trimmed === 'no') {
+    return false;
+  }
+  return null;
+}
+
+function parseNumber(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const parsed = Number.parseFloat(trimmed);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function normalisePerson(record) {
+  const isFaculty = parseBoolean(record.is_faculty);
+  const now = new Date().toISOString();
+  return {
+    id: record.id || generateDeterministicId(record.slug || record.display_name),
+    first_name: emptyToNull(record.first_name),
+    middle_name: emptyToNull(record.middle_name),
+    last_name: emptyToNull(record.last_name),
+    suffix: emptyToNull(record.suffix),
+    display_name: record.display_name?.trim() || buildDisplayName(record),
+    slug: record.slug?.trim() || slugify(buildDisplayName(record)),
+    bio: emptyToNull(record.bio),
+    is_faculty: isFaculty === null ? 0 : (isFaculty ? 1 : 0),
+    created_at: record.created_at?.trim() || now,
+    updated_at: record.updated_at?.trim() || now,
+  };
+}
+
+function buildDisplayName(record) {
+  const parts = [record.first_name, record.middle_name, record.last_name, record.suffix]
+    .map((part) => (part ? part.trim() : ''))
+    .filter((part) => part.length > 0);
+  return parts.join(' ').trim();
+}
+
+function slugify(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function generateDeterministicId(seed) {
+  if (!seed) {
+    return `auto-${Math.random().toString(36).slice(2, 10)}`;
+  }
+  return `auto-${Buffer.from(seed).toString('hex').slice(0, 16)}`;
+}
+
+function normaliseCohort(record) {
+  return {
+    id: record.id || generateDeterministicId(record.year || record.label),
+    year: parseNumber(record.year) ?? null,
+    label: record.label?.trim() || (record.year ? `Class of ${record.year}` : null),
+  };
+}
+
+function normalisePersonCohort(record) {
+  const isPresident = parseBoolean(record.is_class_president);
+  return {
+    person_id: record.person_id?.trim(),
+    cohort_id: record.cohort_id?.trim(),
+    is_class_president: isPresident === null ? 0 : (isPresident ? 1 : 0),
+    homeroom: emptyToNull(record.homeroom),
+    notes: emptyToNull(record.notes),
+  };
+}
+
+function normalisePhoto(record) {
+  return {
+    id: record.id || generateDeterministicId(record.sha256),
+    sha256: record.sha256?.trim(),
+    ext: (record.ext?.trim() || '').replace('.', '').toLowerCase(),
+    width: parseNumber(record.width),
+    height: parseNumber(record.height),
+    bytes: parseNumber(record.bytes),
+    caption: emptyToNull(record.caption),
+    credit: emptyToNull(record.credit),
+    created_at: record.created_at?.trim() || null,
+  };
+}
+
+function normalisePersonPhoto(record) {
+  const isPrimary = parseBoolean(record.is_primary);
+  return {
+    person_id: record.person_id?.trim(),
+    photo_id: record.photo_id?.trim(),
+    kind: record.kind?.trim() || 'portrait',
+    is_primary: isPrimary === null ? 0 : (isPrimary ? 1 : 0),
+  };
+}
+
+function normalisePublication(record) {
+  return {
+    id: record.id?.trim() || generateDeterministicId(record.slug || record.title),
+    title: record.title?.trim() || 'Untitled Publication',
+    issue_date: emptyToNull(record.issue_date),
+    volume: emptyToNull(record.volume),
+    number: emptyToNull(record.number),
+    slug: record.slug?.trim() || slugify(record.title ?? 'publication'),
+    cover_photo_id: emptyToNull(record.cover_photo_id),
+    flipbook_manifest_path: emptyToNull(record.flipbook_manifest_path),
+  };
+}
+
+function normaliseArchiveItem(record) {
+  return {
+    id: record.id?.trim() || generateDeterministicId(record.slug || record.title),
+    title: record.title?.trim() || 'Archive Item',
+    year: parseNumber(record.year),
+    kind: (record.kind?.trim() || 'photo').toLowerCase(),
+    photo_id: emptyToNull(record.photo_id),
+    flipbook_manifest_path: emptyToNull(record.flipbook_manifest_path),
+    description: emptyToNull(record.description),
+  };
+}

--- a/tools/importer/lib/paths.js
+++ b/tools/importer/lib/paths.js
@@ -1,0 +1,44 @@
+import path from 'node:path';
+import { ensureDir } from './fs.js';
+
+export const DEFAULT_CONTENT_ROOT = path.resolve('content');
+
+export function resolveContentPaths(contentRoot = DEFAULT_CONTENT_ROOT) {
+  const root = path.resolve(contentRoot);
+  const dbDir = path.join(root, 'db');
+  const assetsDir = path.join(root, 'assets');
+  const imagesDir = path.join(assetsDir, 'img');
+  const flipbooksDir = path.join(assetsDir, 'flipbooks');
+  const derivativesDir = path.join(root, 'derivatives');
+  const thumbDir = path.join(derivativesDir, 'thumb');
+  const screenDir = path.join(derivativesDir, 'screen');
+  const logsDir = path.join(root, 'logs');
+  return {
+    root,
+    dbDir,
+    stagedDb: path.join(dbDir, 'app.db.staging'),
+    activeDb: path.join(dbDir, 'app.db'),
+    backupDb: path.join(dbDir, 'app.db.backup'),
+    assetsDir,
+    imagesDir,
+    flipbooksDir,
+    derivativesDir,
+    thumbDir,
+    screenDir,
+    logsDir,
+  };
+}
+
+export async function ensureContentLayout(contentRoot = DEFAULT_CONTENT_ROOT) {
+  const paths = resolveContentPaths(contentRoot);
+  await Promise.all([
+    ensureDir(paths.root),
+    ensureDir(paths.dbDir),
+    ensureDir(paths.imagesDir),
+    ensureDir(paths.flipbooksDir),
+    ensureDir(paths.thumbDir),
+    ensureDir(paths.screenDir),
+    ensureDir(paths.logsDir),
+  ]);
+  return paths;
+}

--- a/tools/importer/lib/sqlite.js
+++ b/tools/importer/lib/sqlite.js
@@ -1,0 +1,162 @@
+import { spawn } from 'node:child_process';
+import { logInfo } from './logger.js';
+
+export function runSqliteScript(databasePath, statements, { wrapTransaction = true } = {}) {
+  const script = Array.isArray(statements) ? statements.join('\n') : statements;
+  return new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', ['-batch', databasePath], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `sqlite3 exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+    if (wrapTransaction) {
+      child.stdin.write('PRAGMA foreign_keys = ON;\nBEGIN;\n');
+    }
+    child.stdin.write(`${script}\n`);
+    if (wrapTransaction) {
+      child.stdin.write('COMMIT;\n');
+    }
+    child.stdin.end();
+  });
+}
+
+export async function initialiseDatabase(databasePath) {
+  const schemaStatements = [
+    'PRAGMA journal_mode=WAL;',
+    `CREATE TABLE IF NOT EXISTS person (
+      id TEXT PRIMARY KEY,
+      first_name TEXT,
+      middle_name TEXT,
+      last_name TEXT,
+      suffix TEXT,
+      display_name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      bio TEXT,
+      is_faculty INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT,
+      updated_at TEXT
+    );`,
+    `CREATE TABLE IF NOT EXISTS cohort (
+      id TEXT PRIMARY KEY,
+      year INTEGER UNIQUE,
+      label TEXT
+    );`,
+    `CREATE TABLE IF NOT EXISTS person_cohort (
+      person_id TEXT NOT NULL,
+      cohort_id TEXT NOT NULL,
+      is_class_president INTEGER NOT NULL DEFAULT 0,
+      homeroom TEXT,
+      notes TEXT,
+      PRIMARY KEY (person_id, cohort_id)
+    );`,
+    `CREATE TABLE IF NOT EXISTS photo (
+      id TEXT PRIMARY KEY,
+      sha256 TEXT NOT NULL UNIQUE,
+      ext TEXT NOT NULL,
+      width INTEGER,
+      height INTEGER,
+      bytes INTEGER,
+      caption TEXT,
+      credit TEXT,
+      created_at TEXT
+    );`,
+    `CREATE TABLE IF NOT EXISTS person_photo (
+      person_id TEXT NOT NULL,
+      photo_id TEXT NOT NULL,
+      kind TEXT CHECK(kind IN ('portrait','candid','other')),
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (person_id, photo_id)
+    );`,
+    `CREATE TABLE IF NOT EXISTS publication (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      issue_date TEXT,
+      volume TEXT,
+      number TEXT,
+      slug TEXT NOT NULL UNIQUE,
+      cover_photo_id TEXT,
+      flipbook_manifest_path TEXT
+    );`,
+    `CREATE TABLE IF NOT EXISTS archive_item (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      year INTEGER,
+      kind TEXT CHECK(kind IN ('photo','flipbook')),
+      photo_id TEXT,
+      flipbook_manifest_path TEXT,
+      description TEXT
+    );`,
+    `CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    );`,
+    `CREATE INDEX IF NOT EXISTS idx_person_display_name ON person(display_name);`,
+    `CREATE INDEX IF NOT EXISTS idx_person_cohort_cohort_id ON person_cohort(cohort_id);`,
+    `CREATE INDEX IF NOT EXISTS idx_person_cohort_president ON person_cohort(is_class_president);`,
+    `CREATE INDEX IF NOT EXISTS idx_publication_issue_date ON publication(issue_date DESC);`,
+    `CREATE INDEX IF NOT EXISTS idx_archive_item_year ON archive_item(year DESC);`,
+    `CREATE INDEX IF NOT EXISTS idx_archive_item_kind ON archive_item(kind);`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS person_fts USING fts5(
+      display_name, last_name, first_name,
+      content='person', content_rowid='id'
+    );`,
+  ];
+  await runSqliteScript(databasePath, schemaStatements, { wrapTransaction: false });
+  logInfo(`Initialised SQLite schema at ${databasePath}`);
+}
+
+export function escapeValue(value) {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0';
+  }
+  const stringValue = String(value).replace(/'/g, "''");
+  return `'${stringValue}'`;
+}
+
+export function buildInsert(tableName, columns, rows) {
+  if (!rows || rows.length === 0) {
+    return [];
+  }
+  const columnList = columns.join(', ');
+  return rows.map((row) => {
+    const values = columns.map((column) => escapeValue(row[column]));
+    return `INSERT INTO ${tableName} (${columnList}) VALUES (${values.join(', ')});`;
+  });
+}
+
+export async function runQuery(databasePath, query) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', ['-json', databasePath, query], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderr = '';
+    let stdout = '';
+    child.stderr.setEncoding('utf8');
+    child.stdout.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `sqlite3 exited with code ${code}`));
+      } else {
+        try {
+          resolve(JSON.parse(stdout || '[]'));
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add an offline Node CLI for importing, promoting, rolling back, and auditing signed content packs
- stage packs into SQLite with schema migrations, hashed asset syncing, derivative generation, and integrity checks
- document the tooling workflow and add an npm script alias for kiosk maintenance commands

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690c937218708326b5d33ea7df45d0da